### PR TITLE
Fix bug with ranges larger than 2**31 in buffer.toString() method

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -820,12 +820,12 @@ Buffer.prototype.toString = function toString(encoding, start, end) {
   else if (start >= len)
     return '';
   else
-    start |= 0;
+    start = MathTrunc(start) || 0;
 
   if (end === undefined || end > len)
     end = len;
   else
-    end |= 0;
+    end = MathTrunc(end) || 0;
 
   if (end <= start)
     return '';

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -2,7 +2,6 @@
 
 require('../common');
 const assert = require('assert');
-
 const rangeBuffer = Buffer.from('abc');
 
 // If start >= buffer's length, empty string will be returned
@@ -97,4 +96,11 @@ assert.throws(() => {
   code: 'ERR_UNKNOWN_ENCODING',
   name: 'TypeError',
   message: 'Unknown encoding: null'
+});
+
+// Buffer.toString() should be able to handle buffers greater than INTMAX but less than kMaxLength
+assert.doesNotThrow(() => {
+  const INT_MAX = 2 ** 31 - 1;
+  const bigBuffer = Buffer.alloc(INT_MAX + 3);
+  bigBuffer.toString('utf8', INT_MAX + 1, INT_MAX + 2);
 });


### PR DESCRIPTION
This PR is fixing the bug reported on [this issue](https://github.com/nodejs/node/issues/52298)

When we create buffers larger than 2ˆ31 and try to call toString passing start and end also larger than 2ˆ31 (but still smaller than the size of the buffer), we end up with an ERR_OUT_OF_RANGE.

In this PR, we're adding a unit test to validate this scenario. Initially, this error happens:
<img width="797" alt="Captura de Tela 2024-06-20 às 22 10 03" src="https://github.com/Miller-GS/node/assets/91481595/784a417f-292b-4514-86a8-f01e29ba605e">

We figured out that this error is caused by the bitwise-or operation done to cast "start" and "end" to numbers. This operation only supports positive integers up to 2ˆ31. After, it will truncate and even consider them as negative numbers due to interpreting them as a 2's complement. After changing this to a MathTrunc instead, all tests passed correctly:
<img width="720" alt="Captura de Tela 2024-06-20 às 22 10 41" src="https://github.com/Miller-GS/node/assets/91481595/dbb3a0d3-d480-4d05-9792-fff7c807f040">
